### PR TITLE
use crazy-max/ghaction-import-gpg to import gpg key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,3 @@
-# This GitHub action can publish assets for release when a tag is created.
-# Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
-#
-# This uses an action (hashicorp/ghaction-import-gpg) that assumes you set your 
-# private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
-# secret. If you would rather own your own GPG handling, please fork this action
-# or use an alternative one for key handling.
-#
-# You will need to pass the `--batch` flag to `gpg` in your signing step 
-# in `goreleaser` to indicate this is being used in a non-interactive mode.
-#
 name: release
 on:
   push:
@@ -18,37 +7,23 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v3
-      -
-        name: Unshallow
-        run: git fetch --prune --unshallow
-      -
-        name: Set up Go
-        uses: actions/setup-go@v3
+      - uses: actions/checkout@v3
+      - run: git fetch --prune --unshallow
+      - uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
           cache: true
 
-      - 
-        id: import_gpg
-        run: |
-          set -x
-          echo -e "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --import --batch --no-tty
-          echo "hello world" > temp.txt
-          gpg --detach-sig --yes -v --output=/dev/null --pinentry-mode loopback --passphrase "${{ secrets.PASSPHRASE }}" temp.txt
-          rm temp.txt
-          fingerprint=$(gpg --with-colons --list-keys | awk -F: '/^pub/ { print $5 }')
-          echo "::set-output name=fingerprint::$fingerprint"
+      - id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v5
+        env:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
 
-      -
-        name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3.0.0
+      - uses: goreleaser/goreleaser-action@v3.0.0
         with:
           version: latest
           args: release --rm-dist
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-          # GitHub sets this automatically
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v5
-        env:
+        with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
 


### PR DESCRIPTION
We had inlined the action source to get around https://github.com/hashicorp/ghaction-import-gpg/issues/11 but the advice now seems to be just to use the upstream action. So let's do that.

This also removes some unnecessary step names and comments.