### PR TITLE
add working_dir attribute to ko_resolve resource

### DIFF
--- a/docs/resources/resolve.md
+++ b/docs/resources/resolve.md
@@ -47,6 +47,7 @@ output "manifests" {
 - `sbom` (String) The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m).
 - `selector` (String) Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
 - `tags` (List of String) Which tags to use for the produced image instead of the default 'latest' tag
+- `working_dir` (String) Working directory for the build
 
 ### Read-Only
 

--- a/internal/provider/resource_ko_resolve.go
+++ b/internal/provider/resource_ko_resolve.go
@@ -80,6 +80,13 @@ func resolveConfig() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				ForceNew:    true,
 			},
+			WorkingDirKey: {
+				Description: "Working directory for the build",
+				Optional:    true,
+				Default:     ".",
+				Type:        schema.TypeString,
+				ForceNew:    true,
+			},
 
 			// Computed fields
 			ManifestsKey: {
@@ -147,6 +154,10 @@ func NewResolver(d *schema.ResourceData, meta interface{}) (*resolver, error) {
 
 	if p, ok := d.Get(SelectorKey).(string); ok {
 		r.so.Selector = p
+	}
+
+	if p, ok := d.Get(WorkingDirKey).(string); ok {
+		r.bo.WorkingDirectory = p
 	}
 
 	return r, nil


### PR DESCRIPTION
the lack of this is preventing any real usefulness for `ko_resolve`