### PR TITLE
use distroless.dev/static as default base image

### DIFF
--- a/internal/provider/resource_ko_image.go
+++ b/internal/provider/resource_ko_image.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	defaultBaseImage = "gcr.io/distroless/static:nonroot"
+	defaultBaseImage = "distroless.dev/static"
 	version          = "devel"
 )
 


### PR DESCRIPTION
This matches `ko` as of v0.12.