### PR TITLE
allow image resource to configure exact repo

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -17,15 +17,14 @@ TF_ACC=1 go test ./internal/provider/...
 This relies on https://www.terraform.io/cli/config/config-file#implied-local-mirror-directories
 
 ```
-KO_DOCKER_REPO=gcr.io/jason-chainguard 
 rm .terraform.lock.hcl && \
     go build -o ~/.terraform.d/plugins/registry.terraform.io/chainguard-dev/ko/0.0.100/darwin_arm64/terraform-provider-ko && \
     terraform init && \
-    terraform apply -var project=jason-chainguard
+    terraform apply
 ```
 
 Also update `version = "0.0.0"` in the .tf file.
 
-This builds the provider code into the correct local mirror location, installs the provider using that location, 
+This builds the provider code into the correct local mirror location, installs the provider using that location,
 
 Don't forget to delete the provider from the local mirror if you want to use the released provider later.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,4 +23,5 @@ provider "ko" {
 
 ### Optional
 
-- `docker_repo` (String) Container repositor to publish images to. Defaults to `KO_DOCKER_REPO` env var
+- `docker_repo` (String) [DEPRECATED: use `repo`] Container repository to publish images to. Defaults to `KO_DOCKER_REPO` env var
+- `repo` (String) Container repository to publish images to. Defaults to `KO_DOCKER_REPO` env var

--- a/docs/resources/image.md
+++ b/docs/resources/image.md
@@ -29,6 +29,7 @@ resource "ko_image" "example" {
 
 - `base_image` (String) base image to use
 - `platforms` (List of String) Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+- `repo` (String) Container repository to publish images to. If set, this overrides the provider's docker_repo, and the image name will be exactly the specified `repo`, without the importpath appended.
 - `sbom` (String) The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m).
 - `working_dir` (String) working directory for the build
 

--- a/internal/provider/const.go
+++ b/internal/provider/const.go
@@ -17,20 +17,22 @@ const (
 	BaseImageKey = "base_image"
 	// TagsKey is used for common "tags" resource attribute
 	TagsKey = "tags"
-	// TagOnlyKey used for common "tag_only" resource attribute
+	// TagOnlyKey is used for common "tag_only" resource attribute
 	TagOnlyKey = "tag_only"
-	// PushKey used for common "push" resource attribute
+	// PushKey is used for common "push" resource attribute
 	PushKey = "push"
-	// FilenamesKey used for common "filenames" resource attribute
+	// FilenamesKey is used for common "filenames" resource attribute
 	FilenamesKey = "filenames"
-	// RecursiveKey used for common "recursive" resource attribute
+	// RecursiveKey is used for common "recursive" resource attribute
 	RecursiveKey = "recursive"
-	// SelectorKey used for common "selector" resource attribute
+	// SelectorKey is used for common "selector" resource attribute
 	SelectorKey = "selector"
-	// ImageRefKey used for common "image_ref" resource attribute
+	// ImageRefKey is used for common "image_ref" resource attribute
 	ImageRefKey = "image_ref"
-	// ManifestsKey used for common "manifests" resource attribute
+	// ManifestsKey is used for common "manifests" resource attribute
 	ManifestsKey = "manifests"
+	// RepoKey is used for common "repo" resource attribute
+	RepoKey = "repo"
 )
 
 func StringSlice(in []interface{}) []string {


### PR DESCRIPTION
Progress toward https://github.com/chainguard-dev/terraform-provider-ko/issues/37

With this change there are now three places you can configure the repo:

1. set the `KO_DOCKER_REPO` env var and everything just works, you get `ko build -P` behavior.
1. set the provider's `repo` or `docker_repo` (deprecated); this overrides (1), you get `ko build -P` behavior.
1. set the image resource's `repo`; this overrides (1) and (2), and you get `ko build --bare` behavior.