### PR TITLE
support basic_auth at the provider level

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,5 +23,6 @@ provider "ko" {
 
 ### Optional
 
+- `basic_auth` (String) Basic auth to use to authorize requests
 - `docker_repo` (String) [DEPRECATED: use `repo`] Container repository to publish images to. Defaults to `KO_DOCKER_REPO` env var
 - `repo` (String) Container repository to publish images to. Defaults to `KO_DOCKER_REPO` env var


### PR DESCRIPTION
This is intended to be used with something like https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecr_authorization_token to provide `ko`-provider-wide auth for all requests.

As an example I haven't yet tried myself, to authorize pushes to an ECR repo:

```
data "aws_ecr_authorization_token" "token" {}

resource "aws_ecr_repository" "foo" {
  name = "foo"
}

provider "ko" {
  docker_repo = aws_ecr_repository.foo.name
  basic_auth = aws_ecr_authorization_token.token.authorization_token
}
```

Help with #37 